### PR TITLE
Bug fix: correct variable name

### DIFF
--- a/crob.php
+++ b/crob.php
@@ -181,9 +181,9 @@ function icecatCategoryTable($xml)
     ob_flush();
     flush();
 
-    $cateories_list = $xml->children()[0]->children()[0];
+    $categories_list = $xml->children()[0]->children()[0];
     $c = [];
-    foreach($cateories_list as $category) {
+    foreach($categories_list as $category) {
         $ci=(int)$category['ID'];
         $cp=(int)$category->ParentCategory['ID'];
         $cn=(string)$category->Name[0]['Value'];


### PR DESCRIPTION
## Summary
- fix typo `cateories_list` -> `categories_list`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416e7fec888330bb03c27faf93019e